### PR TITLE
Remove GitHub Copilot extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
     "vscode": {
       "extensions": [
         "DavidAnson.vscode-markdownlint",
-        "GitHub.copilot",
         "GitHub.copilot-chat",
         "Tyriar.sort-lines",
         "bradzacher.vscode-copy-filename",


### PR DESCRIPTION
This pull request makes a small update to the development container configuration by removing the `GitHub.copilot` extension from the list of recommended VS Code extensions. This change helps streamline the development environment and may reduce unnecessary extension clutter.Removed GitHub Copilot extension from devcontainer.