### PR TITLE
update: bump bot-pr-auto-approve-merge workflow ref

### DIFF
--- a/.github/workflows/bot-pr.yaml
+++ b/.github/workflows/bot-pr.yaml
@@ -5,4 +5,4 @@ permissions:
   pull-requests: write
 jobs:
   call-auto-merge:
-    uses: gvatsal60/.github/.github/workflows/bot-pr-auto-approve-merge.yaml@479b5d9df07f3e1fc7e8355595fbb7689189b17d
+    uses: gvatsal60/.github/.github/workflows/bot-pr-auto-approve-merge.yaml@08d0834f1b687dbab5353c7fb066d6b938699609


### PR DESCRIPTION
This pull request updates the workflow configuration to reference a newer version of the reusable workflow used for auto-approving and merging pull requests.

Workflow update:

* Updated the `call-auto-merge` job in `.github/workflows/bot-pr.yaml` to use a newer commit of the `bot-pr-auto-approve-merge.yaml` workflow.