### PR TITLE
fix: add contents: write permission to bot-pr workflow

### DIFF
--- a/.github/workflows/bot-pr.yaml
+++ b/.github/workflows/bot-pr.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
 permissions:
   pull-requests: write
+  contents: write
 jobs:
   call-auto-merge:
     uses: gvatsal60/.github/.github/workflows/bot-pr-auto-approve-merge.yaml@08d0834f1b687dbab5353c7fb066d6b938699609


### PR DESCRIPTION
This pull request makes a small update to the workflow permissions, granting write access to repository contents in the `.github/workflows/bot-pr.yaml` file. This change is likely required for the workflow to perform actions such as updating files or merging pull requests.

- Permissions Update:
  * Added `contents: write` permission to the workflow to allow modification of repository contents.