### PR TITLE
Simplify curl alias installation in postCreateScript

### DIFF
--- a/.devcontainer/postCreateScript.sh
+++ b/.devcontainer/postCreateScript.sh
@@ -31,7 +31,6 @@ readonly UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 ##########################################################################################
 # Functions
 ##########################################################################################
-
 curl_https() {
     if ! command -v curl >/dev/null 2>&1; then
         echo "Error: curl is not installed. Aborting." >&2
@@ -46,13 +45,8 @@ curl_https() {
 
 # Install Linux aliases from external script using curl and execute immediately
 # Note: Make sure to review scripts fetched from external sources for security reasons
-if command -v curl >/dev/null 2>&1; then
-    curl_https "${ALIAS_SRC_URL}" | sh
-    curl_https "${UV_INSTALL_URL}" | sh
-else
-    echo "Error: curl is not installed. Unable to use Linux aliases"
-    exit 1
-fi
+curl_https "${ALIAS_SRC_URL}" | sh
+curl_https "${UV_INSTALL_URL}" | sh
 
 # As bind mounts not supported in GitHub Codespaces
 if [ -n "${CODESPACE_NAME}" ]; then


### PR DESCRIPTION
Removed the check for curl installation before executing curl commands for alias installation.